### PR TITLE
[loki-simple-scalable] Use policy/v1 apiVersion for PodDisruptionBudget when possible

### DIFF
--- a/charts/loki-simple-scalable/Chart.yaml
+++ b/charts/loki-simple-scalable/Chart.yaml
@@ -3,7 +3,7 @@ name: loki-simple-scalable
 description: Helm chart for Grafana Loki in simple, scalable mode
 type: application
 appVersion: 2.5.0
-version: 1.0.0
+version: 1.1.0
 home: https://grafana.github.io/helm-charts
 sources:
   - https://github.com/grafana/loki

--- a/charts/loki-simple-scalable/templates/_helpers.tpl
+++ b/charts/loki-simple-scalable/templates/_helpers.tpl
@@ -206,3 +206,12 @@ Create the service endpoint including port for MinIO.
 {{- printf "%s-%s.%s.svc:%s" .Release.Name "minio" .Release.Namespace (.Values.minio.service.port | toString) -}}
 {{- end -}}
 {{- end -}}
+
+{{/* Return the appropriate apiVersion for PodDisruptionBudget. */}}
+{{- define "loki.podDisruptionBudget.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}
+    {{- print "policy/v1" -}}
+  {{- else -}}
+    {{- print "policy/v1beta1" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/loki-simple-scalable/templates/gateway/poddisruptionbudget-gateway.yaml
+++ b/charts/loki-simple-scalable/templates/gateway/poddisruptionbudget-gateway.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.gateway.enabled }}
 {{- if gt (int .Values.gateway.replicas) 1 }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "loki.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.gatewayFullname" . }}

--- a/charts/loki-simple-scalable/templates/read/poddisruptionbudget-read.yaml
+++ b/charts/loki-simple-scalable/templates/read/poddisruptionbudget-read.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.read.replicas) 1 }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "loki.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.readFullname" . }}

--- a/charts/loki-simple-scalable/templates/write/poddisruptionbudget-write.yaml
+++ b/charts/loki-simple-scalable/templates/write/poddisruptionbudget-write.yaml
@@ -1,5 +1,5 @@
 {{- if gt (int .Values.write.replicas) 1 }}
-apiVersion: policy/v1beta1
+apiVersion: {{ include "loki.podDisruptionBudget.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "loki.writeFullname" . }}


### PR DESCRIPTION
The PodDisruptionBudget resources are using the deprecated policy/v1beta1 apiVersion.

This commit replaces it by the policy/v1 apiVersion when the cluster has it available.